### PR TITLE
Anti prop mutation

### DIFF
--- a/components/app/index.js
+++ b/components/app/index.js
@@ -51,11 +51,18 @@ export default class Gustave extends Component {
 
   onSaveRecommendation(recommendation) {
     let saved = this.state.saved.concat([recommendation]);
+    let recommendations = this.state.recommendations.filter(rec => recommendation.id !== rec.id);
     this.setState({
       saved,
-      justSaved: true
+      justSaved: true,
+      recommendations,
     });
     this.setState({justSaved: false});
+  }
+
+  onDismissRecommendation(recommendation) {
+    let recommendations = this.state.recommendations.filter(rec => recommendation.id !== rec.id);
+    this.setState({recommendations});
   }
 
   onViewConcierge(navigator, recommendation) {
@@ -101,6 +108,7 @@ export default class Gustave extends Component {
             requestMore={this.onRequestMore.bind(this)}
             isLoadingMore={this.state.isLoadingMore}
             recommendations={this.state.recommendations}
+            dismissRecommendation={this.onDismissRecommendation.bind(this)}
             saveRecommendation={this.onSaveRecommendation.bind(this)}
             viewConcierge={this.onViewConcierge.bind(this, navigator)} />
         );

--- a/components/app/index.js
+++ b/components/app/index.js
@@ -27,7 +27,10 @@ export default class Gustave extends Component {
     name: 'Recommendations',
   };
 
-  onRequestMore() {
+  // Temporary to simulate mutation + optimistic update
+  checkNeedMoreRecs() {
+    if (this.state.recommendations.length) return;
+
     let newRecs = Array.from(data);
     let unsavedNewRecs = _.difference(newRecs, this.state.saved);
 
@@ -58,11 +61,15 @@ export default class Gustave extends Component {
       recommendations,
     });
     this.setState({justSaved: false});
+
+    this.checkNeedMoreRecs(); // Temp
   }
 
   onDismissRecommendation(recommendation) {
     let recommendations = this.state.recommendations.filter(rec => recommendation.id !== rec.id);
     this.setState({recommendations});
+
+    this.checkNeedMoreRecs(); // Temp
   }
 
   onViewConcierge(navigator, recommendation) {
@@ -105,7 +112,6 @@ export default class Gustave extends Component {
         return (
           <RecommendationsScene
             style={styles.scene}
-            requestMore={this.onRequestMore.bind(this)}
             isLoadingMore={this.state.isLoadingMore}
             recommendations={this.state.recommendations}
             dismissRecommendation={this.onDismissRecommendation.bind(this)}

--- a/components/navigation-bar/index.js
+++ b/components/navigation-bar/index.js
@@ -13,7 +13,7 @@ import React, {
 
 import styles from './styles';
 
-export var NavigationBarStyles = styles;
+export {styles as NavigationBarStyles};
 
 export var NavigationBarRouteMapper = {
   LeftButton(route, navigator, index, navState) {

--- a/components/recommendations-scene/index.js
+++ b/components/recommendations-scene/index.js
@@ -12,41 +12,48 @@ import Recommendation from '../recommendation';
 export default class RecommendationsScene extends Component {
 
   static propTypes = {
+    recommendations: React.PropTypes.arrayOf(React.PropTypes.object),
     requestMore: React.PropTypes.func,
+    saveRecommendation: React.PropTypes.func,
+    dismissRecommendation: React.PropTypes.func,
     isLoadingMore: React.PropTypes.bool,
   };
 
+  static defaultProps = {
+    recommendations: [],
+  };
+
+  state = {
+    recommendation: null,
+  };
+
   componentWillMount() {
-    this.setFirstAsCurrent()
+    this.syncRec();
   }
 
   componentWillReceiveProps(nextProps) {
-    if (Boolean(nextProps.recommendations))
-      this.setState({recommendation: nextProps.recommendations[0]});
+    if (!this.state.recommendation && Boolean(nextProps.recommendations)) 
+      this.syncRec(nextProps);
   }
 
   didSwipeLeft() {
-    this.nextRec();
+    this.props.dismissRecommendation(this.state.recommendation);
+    this.syncRec();
   }
 
   didSwipeRight() {
     this.props.saveRecommendation(this.state.recommendation);
-    this.nextRec();
+    this.syncRec();
   }
 
-  nextRec() {
-    this.props.recommendations.shift();
+  // Intentional deviation from React pattern b/c we need manual control 
+  syncRec(nextProps) {
+    let props = nextProps || this.props;
 
-    if (!this.props.recommendations.length) {
-      this.props.requestMore();
-    } else {
-      this.setFirstAsCurrent()
-    }
-  }
+    this.setState({recommendation: props.recommendations[0]});
 
-  setFirstAsCurrent() {
-    if(Boolean(this.props.recommendations))
-      this.setState({recommendation: this.props.recommendations[0]});
+    // if(!this.props.recommendations.length)
+    //   this.props.requestMore();
   }
 
   viewConcierge(){
@@ -54,7 +61,7 @@ export default class RecommendationsScene extends Component {
   }
 
   render() {
-    let currentRecommendation = this.state.recommendation;
+    let currentRecommendation = this.state.recommendation || this.state.testRec;
 
     let leftEdge = <Text style={styles.edgeLabel}>Dismiss</Text>;
     let rightEdge = <Text style={styles.edgeLabel}>Save</Text>;

--- a/components/recommendations-scene/index.js
+++ b/components/recommendations-scene/index.js
@@ -13,10 +13,9 @@ export default class RecommendationsScene extends Component {
 
   static propTypes = {
     recommendations: React.PropTypes.arrayOf(React.PropTypes.object),
-    requestMore: React.PropTypes.func,
     saveRecommendation: React.PropTypes.func,
     dismissRecommendation: React.PropTypes.func,
-    isLoadingMore: React.PropTypes.bool,
+    isLoadingMore: React.PropTypes.bool, // Will prob be replaced with call to this.props.relay.hasOptimisticUpdate
   };
 
   static defaultProps = {
@@ -51,9 +50,6 @@ export default class RecommendationsScene extends Component {
     let props = nextProps || this.props;
 
     this.setState({recommendation: props.recommendations[0]});
-
-    // if(!this.props.recommendations.length)
-    //   this.props.requestMore();
   }
 
   viewConcierge(){
@@ -61,18 +57,18 @@ export default class RecommendationsScene extends Component {
   }
 
   render() {
-    let currentRecommendation = this.state.recommendation || this.state.testRec;
+    let currentRecommendation = this.state.recommendation;
 
     let leftEdge = <Text style={styles.edgeLabel}>Dismiss</Text>;
     let rightEdge = <Text style={styles.edgeLabel}>Save</Text>;
 
     if (!currentRecommendation) {
       return (
-        <View style={[this.props.style, styles.scene]}>
+        <View style={[this.props.style, styles.scene, styles.empty]}>
           { (this.props.isLoadingMore) ?
-            <Text>Loading More...</Text>
+            <Text style={styles.emptyText}>Loading recommendations...</Text>
             :
-            <Text>You are shit out of luck.</Text>
+            <Text style={styles.emptyText}>No recommendations available.</Text>
           }
         </View>
       );

--- a/components/recommendations-scene/styles.js
+++ b/components/recommendations-scene/styles.js
@@ -7,6 +7,16 @@ export default StyleSheet.create({
     flex: 1,
   },
 
+  empty: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  emptyText: {
+    color: '#fff',
+    textAlign: 'center',
+  },
+
   edgeLabel: {
     padding: 10,
     color: '#fff',


### PR DESCRIPTION
I refactored some of the stuff we did last night to avoid mutating props, which is huge violation of React's paradigm. State is guaranteed to be owned by a component, but props are supposed to be owned by whatever passes them in. 
 
Instead, the app component now mutates recommendations (state), which get passed into the scene component as a property, rather that the scene mutating the recommendations (prop). This means the scene must manually keep track of state syncing, but that's an intentional break from the paradigm because we don't want automatic state syncing (we don't want to switch the current recommendation just because the list changes until after the user takes an action).

I'm way more comfortable with a component manually syncing state than mutating props, since the former shouldn't have any unintended consequences since the component owns state, but the latter might have unintended consequences since React assumes that a component will never mutate props. 